### PR TITLE
Feat: 관리자 페이지 유저/게시물 관리 기능 및 세션 연장 로직 구현

### DIFF
--- a/src/main/java/com/est/b3/config/SecurityConfig.java
+++ b/src/main/java/com/est/b3/config/SecurityConfig.java
@@ -20,7 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final CustomOAuth2UserService customOAuth2UserService; // ✅ OAuth2UserService 주입
+    private final CustomOAuth2UserService customOAuth2UserService; // OAuth2UserService 주입
     private final Dotenv dotenv = Dotenv.load();
 
     @Bean

--- a/src/main/java/com/est/b3/config/security/OAuth2SuccessController.java
+++ b/src/main/java/com/est/b3/config/security/OAuth2SuccessController.java
@@ -32,8 +32,10 @@ public class OAuth2SuccessController {
                 boss.getAddress(),
                 boss.getSiDo(),
                 boss.getGuGun(),
-                boss.getDongEupMyeon()
+                boss.getDongEupMyeon(),
+                boss.getRole()
         );
+
         session.setAttribute("loginBoss", sessionUser);
 
         // 주소 유무에 따라 분기

--- a/src/main/java/com/est/b3/controller/api/AdminController.java
+++ b/src/main/java/com/est/b3/controller/api/AdminController.java
@@ -1,0 +1,128 @@
+package com.est.b3.controller.api;
+
+import com.est.b3.domain.Boss;
+import com.est.b3.dto.SessionUserDTO;
+import com.est.b3.dto.admin.VerifyRequest;
+import com.est.b3.dto.api.ApiResponse;
+import com.est.b3.exception.CustomException;
+import com.est.b3.exception.ErrorCode;
+import com.est.b3.repository.BossRepository;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final BossRepository bossRepository;
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    /**
+     * 관리자 비밀번호 검증 (모달에서 호출)
+     */
+    @PostMapping("/verify")
+    public ResponseEntity<ApiResponse<Void>> verifyAdmin(@RequestBody VerifyRequest request, HttpSession session) {
+
+        SessionUserDTO sessionUser = (SessionUserDTO) session.getAttribute("loginBoss");
+
+
+        if (sessionUser == null) {
+            throw new CustomException(ErrorCode.SESSION_NOT_FOUND);
+        }
+
+
+        Boss boss = bossRepository.findByUserName(sessionUser.getUserName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+
+        // 관리자 권한 확인
+        if (!"ROLE_ADMIN".equals(boss.getRole())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(request.getPassword(), boss.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+
+        // 세션에 관리자 인증 플래그 저장
+        session.setAttribute("adminAuth", true);
+        session.setAttribute("adminAuthExpiry", LocalDateTime.now().plusMinutes(10));
+
+        return ResponseEntity.ok(ApiResponse.success(200, "관리자 인증 성공", null));
+    }
+
+    /**
+     * 세션 상태 확인 (AJAX 폴링용)
+     */
+    @GetMapping("/check")
+    public ResponseEntity<ApiResponse<Void>> checkAdminSession(HttpSession session) {
+
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+        LocalDateTime expiry = (LocalDateTime) session.getAttribute("adminAuthExpiry");
+
+        if (isAdminAuth == null || !isAdminAuth || expiry == null || expiry.isBefore(LocalDateTime.now())) {
+            session.removeAttribute("adminAuth");
+            session.removeAttribute("adminAuthExpiry");
+
+            throw new CustomException(ErrorCode.ADMIN_SESSION_EXPIRED);
+        }
+
+
+        return ResponseEntity.ok(ApiResponse.success(200, "세션이 유효합니다.", null));
+    }
+
+    /**
+     * 세션 남은 시간 확인
+     */
+    @GetMapping("/remaining-time")
+    public ResponseEntity<ApiResponse<Long>> getRemainingTime(HttpSession session) {
+
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+        LocalDateTime expiry = (LocalDateTime) session.getAttribute("adminAuthExpiry");
+
+        if (isAdminAuth == null || !isAdminAuth || expiry == null) {
+            throw new CustomException(ErrorCode.ADMIN_SESSION_EXPIRED);
+        }
+
+        long remainingSeconds = java.time.Duration.between(LocalDateTime.now(), expiry).getSeconds();
+
+        if (remainingSeconds <= 0) {
+            session.removeAttribute("adminAuth");
+            session.removeAttribute("adminAuthExpiry");
+
+            throw new CustomException(ErrorCode.ADMIN_SESSION_EXPIRED);
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(200, "남은 시간", remainingSeconds));
+    }
+
+
+    /**
+     * 세션 남은 시간 연장
+     */
+    @PostMapping("/verify/extend")
+    public ResponseEntity<ApiResponse<Void>> extendAdminSession(HttpSession session) {
+
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+
+        if (isAdminAuth == null || !isAdminAuth) {
+
+            throw new CustomException(ErrorCode.ADMIN_SESSION_EXPIRED);
+        }
+
+        session.setAttribute("adminAuthExpiry", LocalDateTime.now().plusMinutes(10));
+
+        return ResponseEntity.ok(ApiResponse.success(200, "세션 연장 성공", null));
+    }
+
+
+}

--- a/src/main/java/com/est/b3/controller/api/AdminPostController.java
+++ b/src/main/java/com/est/b3/controller/api/AdminPostController.java
@@ -1,0 +1,53 @@
+package com.est.b3.controller.api;
+
+import com.est.b3.domain.Restaurant;
+import com.est.b3.dto.admin.AdminPostResponse;
+import com.est.b3.dto.api.ApiResponse;
+import com.est.b3.exception.CustomException;
+import com.est.b3.exception.ErrorCode;
+import com.est.b3.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/posts")
+@RequiredArgsConstructor
+public class AdminPostController {
+
+    private final RestaurantRepository restaurantRepository;
+
+    /**
+     * 게시물 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminPostResponse>>> getAllPosts() {
+        List<Restaurant> restaurants = restaurantRepository.findAll();
+
+        List<AdminPostResponse> responses = restaurants.stream()
+                .map(AdminPostResponse::new)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(200, "게시물 목록 조회 성공", responses));
+    }
+
+    /**
+     * 게시물 공개/비공개 상태 토글
+     */
+    @PutMapping("/{id}/toggle")
+    public ResponseEntity<ApiResponse<Void>> togglePostState(@PathVariable Long id) {
+        Restaurant restaurant = restaurantRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        restaurant.toggleState();
+        restaurantRepository.save(restaurant);
+
+        String message = restaurant.getState() == 1
+                ? "게시물이 공개 처리되었습니다."
+                : "게시물이 비공개 처리되었습니다.";
+
+        return ResponseEntity.ok(ApiResponse.success(200, message, null));
+    }
+}

--- a/src/main/java/com/est/b3/controller/api/AdminUserController.java
+++ b/src/main/java/com/est/b3/controller/api/AdminUserController.java
@@ -1,0 +1,55 @@
+package com.est.b3.controller.api;
+
+import com.est.b3.domain.Boss;
+import com.est.b3.dto.admin.AdminUserResponse;
+import com.est.b3.dto.api.ApiResponse;
+import com.est.b3.exception.CustomException;
+import com.est.b3.exception.ErrorCode;
+import com.est.b3.repository.BossRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final BossRepository bossRepository;
+
+    /**
+     * 유저 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> getAllUsers() {
+
+        List<Boss> bosses = bossRepository.findAll();
+
+        List<AdminUserResponse> responses = bosses.stream()
+                .map(AdminUserResponse::new)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(200, "유저 목록 조회 성공", responses));
+    }
+
+
+    /**
+     * 유저 상태 토글 (1=활성 → 0=탈퇴, 0=탈퇴 → 1=활성)
+     */
+    @PutMapping("/{id}/toggle")
+    public ResponseEntity<ApiResponse<Void>> toggleUserState(@PathVariable Long id) {
+
+        Boss boss = bossRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        boss.toggleState();
+
+        bossRepository.save(boss);
+
+        String message = boss.getState() == 1 ? "회원이 복구되었습니다." : "회원이 탈퇴 처리되었습니다.";
+
+        return ResponseEntity.ok(ApiResponse.success(200, message, null));
+    }
+}

--- a/src/main/java/com/est/b3/controller/api/BossController.java
+++ b/src/main/java/com/est/b3/controller/api/BossController.java
@@ -5,6 +5,7 @@ import com.est.b3.dto.api.ApiResponse;
 import com.est.b3.exception.CustomException;
 import com.est.b3.exception.ErrorCode;
 import com.est.b3.service.BossService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,8 +23,11 @@ public class BossController {
      * 회원가입
      */
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody SignupRequest request) {
-        SignupResponse response = bossService.signup(request);
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(
+            @RequestBody SignupRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        SignupResponse response = bossService.signup(request, httpRequest);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/est/b3/controller/api/ValidAddressController.java
+++ b/src/main/java/com/est/b3/controller/api/ValidAddressController.java
@@ -73,7 +73,8 @@ public class ValidAddressController {
         boss.getSiDo(),
         boss.getGuGun(),
         boss.getDongEupMyeon(),
-        boss.getAddress()
+        boss.getAddress(),
+        boss.getRole()
     );
     session.setAttribute("loginBoss", updatedUser);
 

--- a/src/main/java/com/est/b3/controller/page/AdminPageController.java
+++ b/src/main/java/com/est/b3/controller/page/AdminPageController.java
@@ -1,0 +1,70 @@
+package com.est.b3.controller.page;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminPageController {
+
+    @GetMapping("/admin/dashboard")
+    public String dashboard(HttpServletRequest request, HttpSession session, RedirectAttributes redirectAttributes) {
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+
+        if (isAdminAuth == null || !isAdminAuth) {
+
+            // AJAX 요청이라면 JSON 응답
+            if ("XMLHttpRequest".equals(request.getHeader("X-Requested-With"))) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "세션 만료");
+            }
+
+            redirectAttributes.addFlashAttribute("alert", "관리자 인증이 필요합니다.");
+
+            return "redirect:/restaurants";
+        }
+
+        return "admin/dashboard"; // templates/admin/dashboard.html
+    }
+
+    @GetMapping("/admin/users")
+    public String users(HttpSession session, RedirectAttributes redirectAttributes) {
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+
+        if (isAdminAuth == null || !isAdminAuth) {
+            redirectAttributes.addFlashAttribute("alert", "관리자 인증이 필요합니다.");
+            return "redirect:/restaurants";
+        }
+
+        return "admin/users";
+    }
+
+    @GetMapping("/admin/posts")
+    public String posts(HttpSession session, RedirectAttributes redirectAttributes) {
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+
+        if (isAdminAuth == null || !isAdminAuth) {
+            redirectAttributes.addFlashAttribute("alert", "관리자 인증이 필요합니다.");
+            return "redirect:/restaurants";
+        }
+
+        return "admin/posts";
+    }
+
+    @GetMapping("/admin/stats")
+    public String stats(HttpSession session, RedirectAttributes redirectAttributes) {
+        Boolean isAdminAuth = (Boolean) session.getAttribute("adminAuth");
+
+        if (isAdminAuth == null || !isAdminAuth) {
+            redirectAttributes.addFlashAttribute("alert", "관리자 인증이 필요합니다.");
+            return "redirect:/restaurants";
+        }
+
+        return "admin/stats";
+    }
+}

--- a/src/main/java/com/est/b3/domain/Boss.java
+++ b/src/main/java/com/est/b3/domain/Boss.java
@@ -1,5 +1,6 @@
 package com.est.b3.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -17,51 +18,51 @@ public class Boss {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 자동 증가
     private Long id;
 
-    @Column(name = "user_name", length = 100, nullable = false, unique = true)
     private String userName;   // 로그인 ID
 
-    @Column(name = "nick_name", length = 30, nullable = false, unique = true)
     private String nickName;   // 닉네임
 
-    @Column(name = "password", length = 60, nullable = false)
     private String password;   // 암호화된 비밀번호
 
-    @Column(name = "address", length = 50)
     private String address;    // 동네 인증 주소 전체주소
 
-    @Column(name = "siDo", length = 20)
     private String siDo;    // 동네 인증 주소 시도
 
-    @Column(name = "guGun", length = 20)
     private String guGun;    // 동네 인증 주소 구군
 
-    @Column(name = "dongEupMyeon", length = 20)
     private String dongEupMyeon;    // 동네 인증 주소 동읍면
 
-    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "role", length = 10, nullable = false)
     private String role;   // ROLE_USER, ROLE_ADMIN
 
-    @Column(name = "state", nullable = false)
     private Integer state; // 1: 활성, 0: 탈퇴 등
 
+    private String userAgent;  // 가입 당시 브라우저/기기 정보
+
     @OneToMany(mappedBy = "boss", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<Like> likes = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+
         if (this.role == null) this.role = "ROLE_USER";
         if (this.state == null) this.state = 1;
     }
 
-  // 도메인 메서드: 주소 업데이트
+    // 도메인 메서드: 주소 업데이트
     public void updateAddress(String fullAddress, String siDo, String guGun, String dongEupMyeon) {
       this.address = fullAddress;
       this.siDo = siDo;
       this.guGun = guGun;
       this.dongEupMyeon = dongEupMyeon;
-  }
+    }
+
+    // [도메인 메서드] 주소 변경
+    public void toggleState() {
+        this.state = (this.state == 1) ? 0 : 1;
+    }
+
 }

--- a/src/main/java/com/est/b3/domain/Restaurant.java
+++ b/src/main/java/com/est/b3/domain/Restaurant.java
@@ -69,7 +69,7 @@ public class Restaurant {
   @Column(name = "view_count")
   private Integer viewCount = 0;
 
-    public void update(
+  public void update(
         String name,
         String menuName,
         Integer price,
@@ -83,5 +83,9 @@ public class Restaurant {
         this.description = description;
         this.address = address;
         this.photo = photo;
-    }
+  }
+
+  public void toggleState() {
+    this.state = (this.state == 1) ? 0 : 1;
+  }
 }

--- a/src/main/java/com/est/b3/dto/SessionUserDTO.java
+++ b/src/main/java/com/est/b3/dto/SessionUserDTO.java
@@ -16,4 +16,16 @@ public class SessionUserDTO {
     private String siDo;
     private String guGun;
     private String dongEupMyeon;
+    private String role;
+
+    @Override
+    public String toString() {
+        return "SessionUserDTO{" +
+                "userId=" + id +
+                ", username='" + userName + '\'' +
+                ", nickname='" + nickName + '\'' +
+                ", address='" + address + '\'' +
+                ", role='" + role + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/est/b3/dto/admin/AdminPostResponse.java
+++ b/src/main/java/com/est/b3/dto/admin/AdminPostResponse.java
@@ -1,0 +1,27 @@
+package com.est.b3.dto.admin;
+
+import com.est.b3.domain.Restaurant;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AdminPostResponse {
+    private Long id;
+    private String restaurantName;
+    private String menuName;
+    private String bossNickName;
+    private String address;
+    private LocalDateTime createdAt;
+    private Integer state; // 1=공개, 0=비공개
+
+    public AdminPostResponse(Restaurant restaurant) {
+        this.id = restaurant.getId();
+        this.restaurantName = restaurant.getName();
+        this.menuName = restaurant.getMenuName();
+        this.bossNickName = restaurant.getBoss().getNickName();
+        this.address = restaurant.getAddress();
+        this.createdAt = restaurant.getCreatedAt();
+        this.state = restaurant.getState();
+    }
+}

--- a/src/main/java/com/est/b3/dto/admin/AdminUserResponse.java
+++ b/src/main/java/com/est/b3/dto/admin/AdminUserResponse.java
@@ -1,0 +1,34 @@
+package com.est.b3.dto.admin;
+
+import com.est.b3.domain.Boss;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminUserResponse {
+
+    private Long id;
+    private String userName;
+    private String nickName;
+    private String address;
+    private String role;
+    private Integer state;
+    private LocalDateTime createdAt;
+    private String userAgent;
+
+    public AdminUserResponse(Boss boss) {
+        this.id = boss.getId();
+        this.userName = boss.getUserName();
+        this.nickName = boss.getNickName();
+        this.address = boss.getAddress();
+        this.role = boss.getRole();
+        this.state = boss.getState();
+        this.createdAt = boss.getCreatedAt();
+        this.userAgent = boss.getUserAgent();
+    }
+}

--- a/src/main/java/com/est/b3/dto/admin/VerifyRequest.java
+++ b/src/main/java/com/est/b3/dto/admin/VerifyRequest.java
@@ -1,0 +1,10 @@
+package com.est.b3.dto.admin;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VerifyRequest {
+    private String password;
+}

--- a/src/main/java/com/est/b3/exception/ErrorCode.java
+++ b/src/main/java/com/est/b3/exception/ErrorCode.java
@@ -22,6 +22,14 @@ public enum ErrorCode {
   // 세션
   SESSION_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인된 세션이 없습니다."),
 
+  // 어드민
+  UNAUTHORIZED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+  ADMIN_SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "관리자 인증 세션이 만료되었습니다. 다시 인증해주세요."),
+
+
+  // 게시물
+  POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
   NULL_POINTER(HttpStatus.BAD_REQUEST, "값을 입력해주세요"),
   ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 전달되었습니다.");

--- a/src/main/resources/static/css/admin.css
+++ b/src/main/resources/static/css/admin.css
@@ -1,0 +1,80 @@
+/* ===== 관리자 공통 레이아웃 ===== */
+
+/* 전체 레이아웃 - 여백 최소화 */
+.admin-dashboard {
+    min-height: 95vh;
+    max-width: 95vw;
+    margin: 0 auto;
+}
+
+/* 상단 라인 (대시보드 + 타이머 + 탭) */
+.admin-topbar {
+    border-bottom: 1px solid #e9ecef;
+    padding-bottom: 0.75rem;
+}
+
+/* 타이머 문구 */
+#timer-text {
+    font-weight: 500;
+    color: #0d6efd;
+}
+#extendSessionBtn {
+    font-size: 0.85rem;
+    padding: 2px 10px;
+}
+
+/* 오른쪽 탭 */
+.admin-tabs {
+    gap: 1rem;
+}
+
+.admin-tab {
+    font-weight: 500;
+    color: #6c757d;
+    text-decoration: none;
+    transition: color 0.2s ease;
+    padding-bottom: 0.25rem;
+    border-bottom: 2px solid transparent;
+}
+
+.admin-tab:hover {
+    color: #212529;
+}
+
+.admin-tab.active {
+    color: #000;
+    border-bottom-color: #000;
+}
+
+/* 콘텐츠 박스 */
+.admin-content-box {
+    background-color: #fff;
+    border: 1px solid #e9ecef;
+    border-radius: 0.75rem;
+    min-height: 400px;
+}
+
+/* 반응형 */
+@media (max-width: 992px) {
+    .admin-dashboard {
+        padding: 2rem 1rem;
+    }
+    .admin-topbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+    .admin-tabs {
+        flex-wrap: wrap;
+    }
+}
+
+/* 테이블 행 hover 효과 */
+#userTable tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+/* 상태 버튼 스타일 */
+.toggle-btn {
+    min-width: 60px;
+}

--- a/src/main/resources/static/css/header.css
+++ b/src/main/resources/static/css/header.css
@@ -128,6 +128,17 @@
 }
 
 /* ===== 액션 버튼 (채팅/로그아웃) ===== */
+
+.bb-btn-admin {
+    background: linear-gradient(135deg, #f8b600, #f49f00);
+    box-shadow: 0 3px 10px rgba(244,159,0,.25);
+    color: #fff;
+}
+.bb-btn-admin:hover {
+    box-shadow: 0 6px 14px rgba(244,159,0,.3);
+}
+
+
 .bb-btn {
     border: none;
     border-radius: 28px;
@@ -164,3 +175,35 @@
 @media (max-width: 767.98px) {
     .bb-search { display: none; } /* 모바일에선 공간 확보 (필요시 드로어 검색으로 확장) */
 }
+
+#adminAuthModal .modal-backdrop {
+    z-index: 1500 !important;
+}
+
+#adminAuthModal .modal {
+    z-index: 2000 !important;
+}
+
+.modal-backdrop {
+    z-index: 1500 !important;
+}
+
+.modal {
+    z-index: 2000 !important;
+}
+
+#adminAuthModal .modal-content {
+    border-radius: 16px;
+    box-shadow: 0 6px 24px rgba(0,0,0,.12);
+}
+#adminAuthModal .modal-title {
+    color: #2f9eab;
+}
+#adminAuthModal .btn-primary {
+    background: linear-gradient(135deg, #2f9eab, #238f9b);
+    border: none;
+}
+#adminAuthModal .btn-primary:hover {
+    box-shadow: 0 4px 10px rgba(47,158,171,.3);
+}
+

--- a/src/main/resources/static/js/admin-modal.js
+++ b/src/main/resources/static/js/admin-modal.js
@@ -1,0 +1,67 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const adminBtn = document.getElementById("adminAccessBtn");
+    const confirmBtn = document.getElementById("adminConfirmBtn");
+    const passwordInput = document.getElementById("adminPassword");
+    const errorBox = document.getElementById("adminErrorBox");
+
+    // 관리자 페이지 버튼 클릭 시 모달 표시
+    if (adminBtn) {
+        adminBtn.addEventListener("click", () => {
+            const modalEl = document.getElementById("adminAuthModal");
+
+            if (!modalEl) {
+                return;
+            }
+
+            const modal = new bootstrap.Modal(modalEl);
+            modal.show();
+        });
+    }
+
+    // 비밀번호 입력 후 확인 버튼 클릭 시
+    if (confirmBtn) {
+
+        confirmBtn.addEventListener("click", async () => {
+
+            const password = passwordInput.value.trim();
+
+            if (!password) {
+                return;
+            }
+
+            try {
+                const res = await fetch("/api/admin/verify", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ password })
+                });
+
+                const data = await res.json();
+
+                if (res.ok && data.status === 200) {
+
+                    const currentPath = window.location.pathname;
+
+                    //  관리자 페이지 안이라면 새로고침만
+                    if (currentPath.startsWith("/admin")) {
+                        location.reload();
+                    }
+
+                    //  일반 페이지라면 관리자 대시보드로 이동
+                    else {
+                        setTimeout(() => window.location.href = "/admin/dashboard", 300);
+                    }
+
+                } else {
+                    errorBox.style.display = "block";
+                    errorBox.textContent = data.message || "인증 실패";
+                }
+
+            } catch (err) {
+                errorBox.style.display = "block";
+                errorBox.textContent = "서버 오류가 발생했습니다.";
+                console.error(err);
+            }
+        });
+    }
+});

--- a/src/main/resources/static/js/admin-posts.js
+++ b/src/main/resources/static/js/admin-posts.js
@@ -1,0 +1,75 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const tableBody = document.getElementById("postTableBody");
+
+    async function loadPosts() {
+        try {
+            const res = await fetch("/api/admin/posts");
+            const data = await res.json();
+
+            if (!res.ok) {
+                alert("게시물 데이터를 불러올 수 없습니다.");
+                return;
+            }
+
+            const posts = data.data;
+            tableBody.innerHTML = posts
+                .map(
+                    (post, idx) => `
+                    <tr>
+                        <td>${idx + 1}</td>
+                        <td>${post.restaurantName}</td>
+                        <td>${post.menuName}</td>
+                        <td>${post.bossNickName}</td>
+                        <td>${post.address || '-'}</td>
+                        <td>${post.createdAt ? post.createdAt.split('T')[0] : '-'}</td>
+                        <td>
+                            <button 
+                                class="btn btn-sm ${post.state === 1 ? 'btn-outline-danger' : 'btn-outline-secondary'} toggle-btn"
+                                data-id="${post.id}"
+                                data-state="${post.state}">
+                                ${post.state === 1 ? '비공개' : '공개'}
+                            </button>
+                        </td>
+                    </tr>
+                `
+                )
+                .join("");
+
+            bindToggleEvents();
+        } catch (err) {
+            console.error("게시물 목록 로드 실패:", err);
+        }
+    }
+
+    async function bindToggleEvents() {
+        document.querySelectorAll(".toggle-btn").forEach(btn => {
+            btn.addEventListener("click", async (e) => {
+                const id = e.target.dataset.id;
+                const currentState = parseInt(e.target.dataset.state, 10);
+
+                const confirmMessage =
+                    currentState === 0
+                        ? "해당 게시글을 공개 처리 하시겠습니까?"
+                        : "해당 게시글을 비공개 처리 하시겠습니까?";
+
+                if (!confirm(confirmMessage)) return;
+
+                try {
+                    const res = await fetch(`/api/admin/posts/${id}/toggle`, { method: "PUT" });
+                    const data = await res.json();
+
+                    if (res.ok) {
+                        alert(data.message);
+                        loadPosts();
+                    } else {
+                        alert(data.message || "처리 실패");
+                    }
+                } catch (err) {
+                    alert("서버 오류로 처리할 수 없습니다.");
+                }
+            });
+        });
+    }
+
+    await loadPosts();
+});

--- a/src/main/resources/static/js/admin-session.js
+++ b/src/main/resources/static/js/admin-session.js
@@ -1,0 +1,135 @@
+// admin-session.js
+document.addEventListener("DOMContentLoaded", async () => {
+    const timerEl = document.getElementById("session-timer");
+    const modalEl = document.getElementById("adminAuthModal");
+    const timerTextEl = document.getElementById("timer-text");
+
+    // 모달 객체 준비
+    const modal = modalEl ? new bootstrap.Modal(modalEl) : null;
+
+    // -------------------------
+    // [1] 남은 시간 가져오기
+    // -------------------------
+    async function fetchRemainingTime() {
+        try {
+
+            const res = await fetch("/api/admin/remaining-time", {
+                headers: {"X-Requested-With": "XMLHttpRequest"}
+            });
+
+            if (!res.ok) {
+                throw new Error("세션 만료");
+            }
+
+            const data = await res.json();
+
+            return data.data; // 남은 시간(초)
+        } catch (err) {
+
+            console.warn("남은 시간 조회 실패:", err);
+
+            return 0;
+        }
+    }
+
+    // -------------------------
+    // [2] 세션 상태 체크 (1분마다)
+    // -------------------------
+    async function checkAdminSession() {
+        try {
+            const res = await fetch("/api/admin/check", {
+
+                headers: {"X-Requested-With": "XMLHttpRequest"}
+            });
+
+            if (res.status === 401 && modal) {
+                modal.show();
+
+                if (timerEl) {
+                    timerEl.textContent = "세션이 만료되었습니다. 다시 인증해주세요.";
+                }
+            }
+        } catch (err) {
+
+            console.error("세션 확인 중 오류:", err);
+        }
+    }
+
+    // -------------------------
+    // [3] 타이머 초기화 및 실행
+    // -------------------------
+    async function initTimer() {
+        let remaining = await fetchRemainingTime();
+
+        if (!timerEl) {
+            return;
+        } // 타이머 표시 요소 없으면 종료
+
+        if (remaining <= 0) {
+            timerEl.textContent = "세션이 만료되었습니다. 다시 인증해주세요.";
+
+            if (modal) {
+                modal.show();
+            }
+
+            return;
+        }
+
+        // 1초 단위로 감소
+        const timer = setInterval(() => {
+            remaining--;
+
+            const min = Math.floor(remaining / 60);
+            const sec = remaining % 60;
+
+            if (timerTextEl) {
+                timerTextEl.textContent = `${min}분 ${sec < 10 ? "0" + sec : sec}초 남음`;
+            }
+
+
+            if (remaining <= 0) {
+                clearInterval(timer);
+                timerEl.textContent = "세션이 만료되었습니다. 다시 인증해주세요.";
+
+                if (modal) {
+                    modal.show();
+                }
+            }
+        }, 1000);
+    }
+
+    // -------------------------
+    // [4] 주기적 세션 체크 시작
+    // -------------------------
+    setInterval(checkAdminSession, 60000); // 1분마다 백엔드 유효성 체크
+    await initTimer();
+
+
+    // -------------------------
+    // [5] 세션 연장 기능
+    // -------------------------
+    document.getElementById("extendSessionBtn")?.addEventListener("click", async () => {
+        try {
+
+            const res = await fetch("/api/admin/verify/extend", {
+                method: "POST",
+                headers: {"X-Requested-With": "XMLHttpRequest"}
+            });
+
+            const data = await res.json();
+
+            if (res.ok && data.status === 200) {
+                alert("관리자 세션이 10분 연장되었습니다.");
+
+                location.reload(); // 타이머 갱신
+            } else {
+
+                alert(data.message || "연장 실패");
+            }
+        } catch (err) {
+
+            alert("서버 오류로 연장할 수 없습니다.");
+        }
+    });
+
+});

--- a/src/main/resources/static/js/admin-users.js
+++ b/src/main/resources/static/js/admin-users.js
@@ -1,0 +1,65 @@
+document.addEventListener("DOMContentLoaded", async () => {
+    const tableBody = document.getElementById("userTableBody");
+
+    async function loadUsers() {
+        try {
+            const res = await fetch("/api/admin/users");
+            const data = await res.json();
+
+            if (!res.ok) {
+                alert("유저 데이터를 불러올 수 없습니다.");
+                return;
+            }
+
+            const users = data.data;
+            tableBody.innerHTML = users
+                .map(
+                    (user, idx) => `
+                    <tr>
+                        <td>${idx + 1}</td>
+                        <td>${user.userName}</td>
+                        <td>${user.nickName}</td>
+                        <td>${user.createdAt ? user.createdAt.split('T')[0] : '-'}</td>
+                        <td>${user.userAgent || '-'}</td>
+                        <td>
+                            <button 
+                                class="btn btn-sm ${user.state === 1 ? 'btn-outline-danger' : 'btn-outline-secondary'} toggle-btn"
+                                data-id="${user.id}"
+                                data-state="${user.state}">
+                                ${user.state === 1 ? '탈퇴' : '복구'}
+                            </button>
+                        </td>
+                    </tr>
+                `
+                )
+                .join("");
+
+            bindToggleEvents();
+        } catch (err) {
+            console.error("유저 목록 로드 실패:", err);
+        }
+    }
+
+    async function bindToggleEvents() {
+        document.querySelectorAll(".toggle-btn").forEach(btn => {
+            btn.addEventListener("click", async (e) => {
+                const id = e.target.dataset.id;
+                try {
+                    const res = await fetch(`/api/admin/users/${id}/toggle`, { method: "PUT" });
+                    const data = await res.json();
+
+                    if (res.ok) {
+                        alert(data.message);
+                        loadUsers(); // 새로고침 없이 갱신
+                    } else {
+                        alert(data.message || "처리 실패");
+                    }
+                } catch (err) {
+                    alert("서버 오류로 처리할 수 없습니다.");
+                }
+            });
+        });
+    }
+
+    await loadUsers();
+});

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>관리자 대시보드 | BizBeacon</title>
+
+    <!-- Bootstrap & Icons -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+
+    <!-- 공통 스타일 -->
+    <link th:href="@{/css/header.css}" rel="stylesheet" />
+    <link th:href="@{/css/footer.css}" rel="stylesheet" />
+    <link th:href="@{/css/admin.css}" rel="stylesheet" /> <!-- ✅ 새 버전 -->
+</head>
+
+<body>
+<!-- 헤더 -->
+<div th:replace="partials/logined-header :: logined-header"></div>
+
+<!-- 메인 -->
+<main class="admin-dashboard container-fluid px-4 py-5">
+
+    <!-- 상단 라인 -->
+    <div class="admin-topbar d-flex justify-content-between align-items-center flex-wrap mb-4">
+        <!-- 왼쪽: 대시보드 제목 + 타이머 -->
+        <div class="d-flex align-items-center flex-wrap gap-3">
+            <h2 class="fw-bold mb-0">관리자 대시보드</h2>
+            <p class="text-muted mb-0" id="session-timer">
+                관리자 인증 만료까지 <span id="timer-text">--</span>
+                <button id="extendSessionBtn" class="btn btn-sm btn-outline-secondary ms-2">연장</button>
+            </p>
+        </div>
+
+        <!-- 오른쪽: 탭 -->
+        <nav class="admin-tabs d-flex align-items-center gap-3">
+            <a th:href="@{/admin/users}" class="admin-tab">
+                <i class="fa-solid fa-users me-1"></i> 유저 관리
+            </a>
+            <a th:href="@{/admin/posts}" class="admin-tab">
+                <i class="fa-solid fa-file-lines me-1"></i> 게시물 관리
+            </a>
+            <a th:href="@{/admin/stats}" class="admin-tab">
+                <i class="fa-solid fa-chart-column me-1"></i> 통계 보기
+            </a>
+        </nav>
+    </div>
+
+    <!-- 메인 콘텐츠 -->
+    <section class="admin-content-box shadow-sm rounded-4 p-5">
+        <div class="text-center text-secondary py-5">
+            <i class="fa-solid fa-chart-line fa-3x mb-3 text-primary"></i>
+            <h5 class="fw-semibold">BizBeacon 관리자 페이지에 오신 것을 환영합니다!</h5>
+            <p class="small text-muted">
+                오른쪽 탭을 클릭하여 유저/게시물/통계 관리를 시작하세요.
+            </p>
+        </div>
+    </section>
+</main>
+
+<!-- 푸터 -->
+<div th:replace="partials/footer :: footer"></div>
+
+<!-- 관리자 인증 모달 -->
+<div th:replace="~{partials/admin-modal :: admin-modal}"></div>
+
+<!-- JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script th:src="@{/js/admin-modal.js}"></script>
+<script th:src="@{/js/admin-session.js}"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/posts.html
+++ b/src/main/resources/templates/admin/posts.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>게시물 관리 | BizBeacon</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+    <link th:href="@{/css/header.css}" rel="stylesheet" />
+    <link th:href="@{/css/footer.css}" rel="stylesheet" />
+    <link th:href="@{/css/admin.css}" rel="stylesheet" />
+</head>
+
+<body>
+<div th:replace="partials/logined-header :: logined-header"></div>
+
+<main class="admin-dashboard container-fluid px-4 py-5">
+
+    <!-- 상단 바 -->
+    <div class="admin-topbar d-flex justify-content-between align-items-center flex-wrap mb-4">
+        <div class="d-flex align-items-center flex-wrap gap-3">
+            <h2 class="fw-bold mb-0">게시물 관리</h2>
+            <p class="text-muted mb-0" id="session-timer">
+                관리자 인증 만료까지 <span id="timer-text">--</span>
+                <button id="extendSessionBtn" class="btn btn-sm btn-outline-secondary ms-2">연장</button>
+            </p>
+        </div>
+
+        <nav class="admin-tabs d-flex align-items-center gap-3">
+            <a th:href="@{/admin/users}" class="admin-tab"><i class="fa-solid fa-users me-1"></i> 유저 관리</a>
+            <a th:href="@{/admin/posts}" class="admin-tab active"><i class="fa-solid fa-file-lines me-1"></i> 게시물 관리</a>
+            <a th:href="@{/admin/stats}" class="admin-tab"><i class="fa-solid fa-chart-column me-1"></i> 통계 보기</a>
+        </nav>
+    </div>
+
+    <!-- 게시물 테이블 -->
+    <section class="admin-content-box shadow-sm rounded-4 p-4">
+        <div class="table-responsive">
+            <table class="table align-middle text-center" id="postTable">
+                <thead class="table-light">
+                <tr>
+                    <th>#</th>
+                    <th>상호명</th>
+                    <th>대표 메뉴</th>
+                    <th>작성자</th>
+                    <th>지역</th>
+                    <th>등록일</th>
+                    <th>상태</th>
+                </tr>
+                </thead>
+                <tbody id="postTableBody">
+                <!-- JS로 데이터 렌더링 -->
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+
+<div th:replace="partials/footer :: footer"></div>
+<div th:replace="~{partials/admin-modal :: admin-modal}"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script th:src="@{/js/admin-session.js}"></script>
+<script th:src="@{/js/admin-posts.js}"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/stats.html
+++ b/src/main/resources/templates/admin/stats.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<script th:src="@{/js/admin-session.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/users.html
+++ b/src/main/resources/templates/admin/users.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>유저 관리 | BizBeacon</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+    <link th:href="@{/css/header.css}" rel="stylesheet" />
+    <link th:href="@{/css/footer.css}" rel="stylesheet" />
+    <link th:href="@{/css/admin.css}" rel="stylesheet" />
+</head>
+
+<body>
+<!-- 헤더 -->
+<div th:replace="partials/logined-header :: logined-header"></div>
+
+<main class="admin-dashboard container-fluid px-4 py-5">
+
+    <!-- 상단 바 -->
+    <div class="admin-topbar d-flex justify-content-between align-items-center flex-wrap mb-4">
+        <div class="d-flex align-items-center flex-wrap gap-3">
+            <h2 class="fw-bold mb-0">유저 관리</h2>
+            <p class="text-muted mb-0" id="session-timer">
+                관리자 인증 만료까지 <span id="timer-text">--</span>
+                <button id="extendSessionBtn" class="btn btn-sm btn-outline-secondary ms-2">연장</button>
+            </p>
+        </div>
+
+        <nav class="admin-tabs d-flex align-items-center gap-3">
+            <a th:href="@{/admin/users}" class="admin-tab active"><i class="fa-solid fa-users me-1"></i> 유저 관리</a>
+            <a th:href="@{/admin/posts}" class="admin-tab"><i class="fa-solid fa-file-lines me-1"></i> 게시물 관리</a>
+            <a th:href="@{/admin/stats}" class="admin-tab"><i class="fa-solid fa-chart-column me-1"></i> 통계 보기</a>
+        </nav>
+    </div>
+
+    <!-- 메인 콘텐츠 -->
+    <section class="admin-content-box shadow-sm rounded-4 p-4">
+        <div class="table-responsive">
+            <table class="table align-middle text-center" id="userTable">
+                <thead class="table-light">
+                <tr>
+                    <th>#</th>
+                    <th>아이디</th>
+                    <th>상호명</th>
+                    <th>가입일</th>
+                    <th>User Agent</th>
+                    <th>상태</th>
+                </tr>
+                </thead>
+                <tbody id="userTableBody">
+                <!-- JS로 데이터 렌더링 -->
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+</main>
+
+<!-- 푸터 -->
+<div th:replace="partials/footer :: footer"></div>
+<div th:replace="~{partials/admin-modal :: admin-modal}"></div>
+
+<!-- JS -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script th:src="@{/js/admin-session.js}"></script>
+<script th:src="@{/js/admin-users.js}"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -65,6 +65,13 @@
         <button type="submit" class="btn btn-primary py-3">로그인</button>
     </form>
 
+    <!-- 구글 로그인 버튼 추가 -->
+    <div class="text-center mt-4">
+        <a href="/oauth2/authorization/google" class="btn btn-primary text-white w-100 py-3">
+            <i class="fa-brands fa-google me-2"></i> Google 계정으로 로그인
+        </a>
+    </div>
+
     <!-- 회원가입 이동 -->
     <div class="text-center mt-3">
         <p>
@@ -72,12 +79,6 @@
         </p>
     </div>
 
-    <!-- 구글 로그인 버튼 추가 -->
-    <div class="text-center mt-4">
-        <a href="/oauth2/authorization/google" class="btn btn-primary text-white w-100 py-3">
-            <i class="fa-brands fa-google me-2"></i> Google 계정으로 로그인
-        </a>
-    </div>
 </main>
 
 <!-- Footer -->

--- a/src/main/resources/templates/partials/admin-modal.html
+++ b/src/main/resources/templates/partials/admin-modal.html
@@ -1,0 +1,26 @@
+<!-- 관리자 인증 모달 (partials/admin-modal.html) -->
+<div th:fragment="admin-modal">
+    <div class="modal fade" id="adminAuthModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content p-3">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title fw-bold">관리자 인증</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="닫기"></button>
+                </div>
+
+                <div class="modal-body">
+                    <p class="text-muted small mb-2">
+                        관리자 페이지 접근을 위해 비밀번호를 다시 입력해주세요.
+                    </p>
+                    <input type="password" id="adminPassword" class="form-control" placeholder="비밀번호 입력" />
+                    <div id="adminErrorBox" class="text-danger mt-2 small" style="display:none;"></div>
+                </div>
+
+                <div class="modal-footer border-0">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">취소</button>
+                    <button type="button" class="btn btn-primary" id="adminConfirmBtn">확인</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/partials/logined-header.html
+++ b/src/main/resources/templates/partials/logined-header.html
@@ -1,41 +1,3 @@
-<!--<header th:fragment="logined-header" class="navbar navbar-expand-lg navbar-light bg-white">-->
-<!--    <div class="container">-->
-<!--        <a th:href="@{/}">-->
-<!--            <img th:src="@{/images/header_logo.png}" alt="Logo" class="header-logo" />-->
-<!--        </a>-->
-
-<!--        &lt;!&ndash; 내비 메뉴 &ndash;&gt;-->
-<!--        <ul class="navbar-nav me-auto mb-2 mb-lg-0 ms-4">-->
-<!--            <li class="nav-item"><a class="nav-link active ms-2 fw-bold" th:href="@{/restaurants}">동네소개</a></li>-->
-<!--            <li class="nav-item"><a class="nav-link ms-2 fw-bold" th:href="@{/address-certify}">동네인증</a></li>-->
-<!--            <li class="nav-item"><a class="nav-link ms-2 fw-bold" th:href="@{/restaurant-detail}">점포관리</a></li>-->
-<!--        </ul>-->
-
-<!--        &lt;!&ndash; 검색창 &ndash;&gt;-->
-<!--        <form class="d-flex me-3" method="get" action="/restaurants/search">-->
-<!--            <input-->
-<!--                class="form-control me-2 search-box"-->
-<!--                type="search"-->
-<!--                name="menu"-->
-<!--                placeholder="찾는 메뉴가 뭐에요?"-->
-<!--                aria-label="search"-->
-<!--            />-->
-<!--            <button class="btn btn-outline-success" type="submit">검색</button>-->
-<!--        </form>-->
-
-
-<!--        &lt;!&ndash; 채팅하기/로그아웃 버튼 &ndash;&gt;-->
-<!--        <div class="d-flex me-3">-->
-<!--            <a th:href="@{/chat}" class="btn chat-btn-outline-dark">채팅하기</a>-->
-<!--        </div>-->
-
-<!--        <div class="d-flex me-3">-->
-<!--            <a th:href="@{/}" class="btn logout-btn-outline-dark">로그아웃</a>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</header>-->
-
-
 <header th:fragment="logined-header" class="navbar navbar-expand-lg sticky-top bb-logined-header">
     <div class="container-fluid px-3 d-flex align-items-center justify-content-between">
 
@@ -80,6 +42,13 @@
             </button>
         </form>
 
+        <!-- 관리자만 보이는 버튼 -->
+        <div th:if="${session.loginBoss != null and session.loginBoss.role == 'ROLE_ADMIN'}">
+            <button class="bb-btn bb-btn-admin" id="adminAccessBtn">
+                <i class="fa-solid fa-user-shield"></i> 관리자 페이지
+            </button>
+        </div>
+
         <!-- 채팅 / 로그아웃 -->
         <div class="d-flex align-items-center gap-2">
             <a th:href="@{/chat}" class="bb-btn bb-btn-chat">
@@ -101,5 +70,5 @@
             if (res.ok) window.location.href = "/";
         });
     </script>
-</header>
 
+</header>

--- a/src/main/resources/templates/restaurants.html
+++ b/src/main/resources/templates/restaurants.html
@@ -7,6 +7,8 @@
         <link th:href="@{/css/style.css}" rel="stylesheet" />
         <link th:href="@{/css/header.css}" rel="stylesheet" />
         <link th:href="@{/css/footer.css}" rel="stylesheet" />
+        <!-- FontAwesome -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
         <!-- 내부 CSS -->
         <style>
             .banner {
@@ -126,6 +128,10 @@
         <!-- Footer -->
         <div th:replace="partials/footer :: footer"></div>
 
+        <!-- 관리자 모달 include -->
+        <div th:replace="~{partials/admin-modal :: admin-modal}"></div>
+
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+        <script th:src="@{/js/admin-modal.js}"></script>
     </body>
 </html>


### PR DESCRIPTION
- 관리자 대시보드 UI 개선 및 상단 탭 구조 정비
- 관리자 세션 만료 타이머 및 연장 기능(admin-session.js) 추가
- 유저 관리 기능 구현
  - 유저 목록 조회 API (/api/admin/users)
  - 상태 토글(활성/탈퇴) 기능 추가
  - User-Agent 정보 수집 및 출력
- 게시물 관리 기능 구현
  - 게시물 목록 조회 API (/api/admin/posts)
  - 공개/비공개 상태 토글 기능 추가
- Boss, Restaurant 엔티티 도메인 메서드 추가 (toggleState 등)
- ErrorCode: POST_NOT_FOUND 추가